### PR TITLE
fix: create backups bucket that is expected

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -186,6 +186,11 @@ resource "google_redis_instance" "gitlab" {
 }
 
 // Cloud Storage
+resource "google_storage_bucket" "gitlab-backups" {
+  name     = "${var.project_id}-gitlab-backups"
+  location = "${var.region}"
+}
+
 resource "google_storage_bucket" "gitlab-uploads" {
   name     = "${var.project_id}-gitlab-uploads"
   location = "${var.region}"


### PR DESCRIPTION
In values.yaml.tpl we reference "${PROJECT_ID}-gitlab-backups"
but unlike all the other cloud storage buckets, this one is 
not created in the main.tf module so far.