### PR TITLE
add explicit secondary cidr ranges, pin provider versions.

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,14 @@
+
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    external    = "~> 1.2.0"
+    google      = "~> 2.18.0"
+    google-beta = "~> 2.18.0"
+    helm        = "~> 0.10"
+    kubernetes  = "~> 1.10.0"
+    template    = "~> 2.1"
+    null        = "~> 2.1"                                                                                                               
+    random      = "~> 2.2"   
+  }
+}


### PR DESCRIPTION
Error when creating GKE cluster with auto secondary ranges:

```
Error: Error waiting for creating GKE cluster: Retry budget exhausted (10 attempts): Google Compute Engine: Invalid value for field 'resource.secondaryIpRanges[1].ipCidrRange': '10.207.16.0/20'. Invalid IPCidrRange: 10.207.16.0/20 conflicts with reserved IP range '10.207.0.0/16'.
```

GKE may have changed something on the API side, the same error occurred with the 2.18 and 3.0 google provider.

This fixes the error by explicitly creating and referencing the secondary ranges on the subnet.

Also included is a `versons.tf` file to lock in the provider versions.