### PR TITLE
remove min_master_version as 1.12 is not available anymore

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -225,7 +225,6 @@ resource "google_container_cluster" "gitlab" {
   project            = "${var.project_id}"
   name               = "gitlab"
   location           = "${var.region}"
-  min_master_version = "1.12"
 
   # We can't create a cluster with no node pool defined, but we want to only use
   # separately managed node pools. So we create the smallest possible default


### PR DESCRIPTION
1.12 is not available in GKE anymore (https://cloud.google.com/kubernetes-engine/docs/release-notes) and this made the module fail (see below).

```
Step #4 - "setup-gitlab": Error: googleapi: Error 400: No valid versions with the prefix "1.12" found., badRequest
Step #4 - "setup-gitlab":
Step #4 - "setup-gitlab":   on .terraform/modules/gke-gitlab/main.tf line 224, in resource "google_container_cluster" "gitlab":
Step #4 - "setup-gitlab":  224: resource "google_container_cluster" "gitlab" {
```