### PR TITLE
Pin Helm provider version to pre-1.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,9 @@
 
 terraform {
   required_version = ">= 0.12.0"
+  required_providers {
+    helm = "~> 0.10"
+  }
 }
 
 provider "google" {


### PR DESCRIPTION
This pins the version of the Helm provider to pre-1.0 releases, i.e. those based on Helm 2, which is currently required by Gitlab. Fixes #23.