### PR TITLE
Adding variable to the Postgres database instance name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,22 @@ Then perform the following commands on the root folder:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| certmanager\_email | Email used to retrieve SSL certificates from Let's Encrypt | string | n/a | yes |
-| gitlab\_db\_password | Password for the GitLab Postgres user | string | `""` | no |
-| project\_id | GCP Project to deploy resources | string | n/a | yes |
-| region | GCP region to deploy resources to | string | `"us-central1"` | no |
+|------|-------------|------|---------|:--------:|
+| certmanager\_email | Email used to retrieve SSL certificates from Let's Encrypt | `any` | n/a | yes |
+| domain | Domain for hosting gitlab functionality (ie mydomain.com would access gitlab at gitlab.mydomain.com) | `string` | `""` | no |
+| gitlab\_address\_name | Name of the address to use for GitLab ingress | `string` | `""` | no |
+| gitlab\_db\_name | Instance name for the GitLab Postgres database. | `string` | `"gitlab-db"` | no |
+| gitlab\_db\_password | Password for the GitLab Postgres user | `string` | `""` | no |
+| gitlab\_runner\_install | Choose whether to install the gitlab runner in the cluster | `bool` | `true` | no |
+| gke\_version | Version of GKE to use for the GitLab cluster | `string` | `"1.14"` | no |
+| project\_id | GCP Project to deploy resources | `any` | n/a | yes |
+| region | GCP region to deploy resources to | `string` | `"us-central1"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| gitlab\_address | IP address where you can connect to your GitLab instance |
 | gitlab\_url | URL where you can access your GitLab instance |
 | root\_password\_instructions | Instructions for getting the root user's password for initial setup |
 

--- a/main.tf
+++ b/main.tf
@@ -147,7 +147,7 @@ resource "google_service_networking_connection" "private_vpc_connection" {
 
 resource "google_sql_database_instance" "gitlab_db" {
   depends_on       = ["google_service_networking_connection.private_vpc_connection"]
-  name             = "gitlab-db"
+  name             = "${var.gitlab_db_name}"
   region           = "${var.region}"
   database_version = "POSTGRES_9_6"
 

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,11 @@ variable "gke_version" {
   default     = "1.14"
 }
 
+variable "gitlab_db_name" {
+  description = "Instance name for the GitLab Postgres database."
+  default     = "gitlab-db"
+}
+
 variable "gitlab_db_password" {
   description = "Password for the GitLab Postgres user"
   default     = ""


### PR DESCRIPTION
Pulling the instance name for the Postgres database out into a var so users can customize it and better support destroy and recreate scenarios.