### PR TITLE
parameterize helm-chart version number; provided additional variable …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -418,6 +418,8 @@ locals {
 }
 
 data "template_file" "helm_values" {
+  # 12.7 changed to "redis.install"
+  # Helm Chart 3.0.0 first to use 12.x
   template = "${file("${path.module}/values.yaml.tpl")}"
 
   vars = {
@@ -442,7 +444,7 @@ resource "helm_release" "gitlab" {
   name       = "gitlab"
   repository = "${data.helm_repository.gitlab.name}"
   chart      = "gitlab"
-  version    = "2.3.7"
+  version    = "${var.helm_chart_version}"
   timeout    = 600
 
   values = ["${data.template_file.helm_values.rendered}"]

--- a/values.yaml.tpl
+++ b/values.yaml.tpl
@@ -17,7 +17,7 @@ global:
 
   ## doc/charts/globals.md#configure-postgresql-settings
   psql:
-    password: 
+    password:
       secret: gitlab-pg
       key: password
     host: ${DB_PRIVATE_IP}
@@ -78,6 +78,7 @@ prometheus:
   install: false
 
 redis:
+  install: false
   enabled: false
 
 gitlab:

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "domain" {
 variable "certmanager_email" {
   description = "Email used to retrieve SSL certificates from Let's Encrypt"
 }
-   
+
 variable "gke_version" {
   description = "Version of GKE to use for the GitLab cluster"
   default     = "1.14"
@@ -55,4 +55,10 @@ variable "gitlab_runner_install" {
 variable "region" {
   default     = "us-central1"
   description = "GCP region to deploy resources to"
+}
+
+variable "helm_chart_version" {
+  type        = string
+  default     = "2.3.7"
+  description = "Helm chart version to install during deployment"
 }


### PR DESCRIPTION
Added a variable for the Helm Chart used during installation.  No changes to default configured value.

In Helm Chart 3.0.0+ a change in the parameter needed for using `redis` was updated from `enable` to `install`.  This change is consistent with the rest of the install method.  An additional configuration line to provide this change for backward compatibility is included in the `values.yaml.tpl` file.