### PR TITLE
moving the Helm Chart version to a Terraform variable with the 2.3.7 …

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -442,7 +442,7 @@ resource "helm_release" "gitlab" {
   name       = "gitlab"
   repository = "${data.helm_repository.gitlab.name}"
   chart      = "gitlab"
-  version    = "2.3.7"
+  version    = "${var.helm_chart_version}"
   timeout    = 600
 
   values = ["${data.template_file.helm_values.rendered}"]

--- a/values.yaml.tpl
+++ b/values.yaml.tpl
@@ -17,7 +17,7 @@ global:
 
   ## doc/charts/globals.md#configure-postgresql-settings
   psql:
-    password: 
+    password:
       secret: gitlab-pg
       key: password
     host: ${DB_PRIVATE_IP}
@@ -79,6 +79,7 @@ prometheus:
 
 redis:
   enabled: false
+  install: false
 
 gitlab:
   gitaly:

--- a/variables.tf
+++ b/variables.tf
@@ -26,7 +26,7 @@ variable "domain" {
 variable "certmanager_email" {
   description = "Email used to retrieve SSL certificates from Let's Encrypt"
 }
-   
+
 variable "gke_version" {
   description = "Version of GKE to use for the GitLab cluster"
   default     = "1.14"
@@ -55,4 +55,10 @@ variable "gitlab_runner_install" {
 variable "region" {
   default     = "us-central1"
   description = "GCP region to deploy resources to"
+}
+
+variable "helm_chart_version" {
+  type        = string
+  default     = "2.3.7"
+  description = "Helm chart version to install during deployment"
 }


### PR DESCRIPTION
Version 2.3.7 of the Helm Chart is set as default for backwards compatibility. Version 3.0 of the Helm chart uses "redis.install" versus "redis.enable" and breaks, an additional variable for the values file has been added to protect for this