### PR TITLE
Adding storage.objectAdmin to the GSA for Gitlab Storage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -103,6 +103,12 @@ resource "google_project_iam_member" "project" {
   member  = "serviceAccount:${google_service_account.gitlab_gcs.email}"
 }
 
+resource "google_project_iam_member" "storageObjectAdmin" {
+  project = "${var.project_id}"
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.gitlab_gcs.email}"
+}
+
 // Networking
 resource "google_compute_network" "gitlab" {
   name                    = "gitlab"


### PR DESCRIPTION
Adding the Storage Object Admin to complement the Storage Admin role.