### PR TITLE
Switch to using GKE module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,8 +23,8 @@ provider "google-beta" {
 }
 
 module "gke_auth" {
-  source  = "git::https://github.com/terraform-google-modules/terraform-google-kubernetes-engine.git//modules/auth?ref=fix/empty-auth"
-  # version = "~> 9.0"
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/auth"
+  version = "~> 9.1"
 
   project_id       = var.project_id
   cluster_name     = module.gke.name

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,12 +15,12 @@
  */
 
 output "gitlab_address" {
-  value       = "${var.gitlab_address_name}" == "" ? "${google_compute_address.gitlab.0.address}" : "${data.google_compute_address.gitlab.0.address}"
+  value       = local.gitlab_address
   description = "IP address where you can connect to your GitLab instance"
 }
 
 output "gitlab_url" {
-  value       = "https://gitlab.${google_compute_address.gitlab.0.address}.xip.io"
+  value       = "https://gitlab.${local.gitlab_address}.xip.io"
   description = "URL where you can access your GitLab instance"
 }
 

--- a/version.tf
+++ b/version.tf
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.12.0"
+  required_providers {
+    google = "~> 3.8"
+    google-beta = "~> 3.8"
+    helm = "~> 0.10"
+    kubernetes = "~> 1.10.0"
+    null = "~> 2.1.2"
+    random = "~> 2.2.1"
+    template = "~> 2.1.2"
+  }
+}


### PR DESCRIPTION
This PR switches to creating the cluster using the [GKE module](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine).

This should have a number of benefits:
1. Better token-based auth (fixes #37)
2. Dedicated service account for node pools (with necessary permissions automatically granted)
3. Simpler support for new GKE features (ex. workload identity)