### PR TITLE
Expose the K8s cluster info as outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,14 @@ Then perform the following commands on the root folder:
 
 | Name | Description |
 |------|-------------|
+| cluster\_ca\_certificate | CA Certificate for the GKE cluster that GitLab is deployed in. |
+| cluster\_location | Location of the GKE cluster that GitLab is deployed in. |
+| cluster\_name | Name of the GKE cluster that GitLab is deployed in. |
 | gitlab\_address | IP address where you can connect to your GitLab instance |
 | gitlab\_url | URL where you can access your GitLab instance |
+| host | Host for the GKE cluster that GitLab is deployed in. |
 | root\_password\_instructions | Instructions for getting the root user's password for initial setup |
+| token | Token for the GKE cluster that GitLab is deployed in. |
 
  <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,6 +24,31 @@ output "gitlab_url" {
   description = "URL where you can access your GitLab instance"
 }
 
+output "cluster_name" {
+  value       = module.gke.name
+  description = "Name of the GKE cluster that GitLab is deployed in."
+}
+
+output "cluster_location" {
+  value       = module.gke.location
+  description = "Location of the GKE cluster that GitLab is deployed in."
+}
+
+output "cluster_ca_certificate" {
+  value       = module.gke_auth.cluster_ca_certificate
+  description = "CA Certificate for the GKE cluster that GitLab is deployed in."
+}
+
+output "host" {
+  value       = module.gke_auth.host
+  description = "Host for the GKE cluster that GitLab is deployed in."
+}
+
+output "token" {
+  value       = module.gke_auth.token
+  description = "Token for the GKE cluster that GitLab is deployed in."
+}
+
 output "root_password_instructions" {
   value = <<EOF
 


### PR DESCRIPTION
This allows users to modify the cluster after its been created. One example use case is setting the RBAC of the GitLab runner pods used in the shared runners.