### PR TITLE
Update so we don't rebuild the domain used for output.gitlab_url

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ provider "kubernetes" {
 // Services
 module "project_services" {
   source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 8.0"
+  version = "~> 9.0"
 
   project_id                  = var.project_id
   disable_services_on_destroy = false
@@ -237,7 +237,7 @@ resource "google_storage_bucket" "gitlab-runner-cache" {
 // GKE Cluster
 module "gke" {
   source  = "terraform-google-modules/kubernetes-engine/google"
-  version = "~> 9.0"
+  version = "~> 12.0"
 
   # Create an implicit dependency on service activation
   project_id = module.project_services.project_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "gitlab_address" {
 }
 
 output "gitlab_url" {
-  value       = "https://gitlab.${local.gitlab_address}.xip.io"
+  value       = "https://${local.domain}"
   description = "URL where you can access your GitLab instance"
 }
 


### PR DESCRIPTION
In `main.tf` `local.domain` is calculated using the `var.domain` and `local.gitlab_address`.  However, in the outputs we rebuild the domain using `local.gitlab_address`.  I think we should just use `local.domain` to build the output value for `gitlab_url`.

Because we rebuild the url using `local.gitlab_address`, the plan phase can produce this error:

```
Error: Invalid template interpolation value

  on .terraform/modules/gke-gitlab/outputs.tf line 23, in output "gitlab_url":
  23:   value       = "https://gitlab.${local.gitlab_address}.xip.io"
    |----------------
    | local.gitlab_address is null
```