### PR TITLE
Allow cleanup of buckets even if there are objects in them

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allow\_future\_deletion | Allows full cleanup of resources by disabling any deletion safe guards | `bool` | `false` | no |
+| allow\_force\_destroy | Allows full cleanup of resources by disabling any deletion safe guards | `bool` | `false` | no |
 | certmanager\_email | Email used to retrieve SSL certificates from Let's Encrypt | `any` | n/a | yes |
 | domain | Domain for hosting gitlab functionality (ie mydomain.com would access gitlab at gitlab.mydomain.com) | `string` | `""` | no |
 | gitlab\_address\_name | Name of the address to use for GitLab ingress | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| allow\_future\_deletion | Allows full cleanup of resources by disabling any deletion safe guards | `bool` | `false` | no |
 | certmanager\_email | Email used to retrieve SSL certificates from Let's Encrypt | `any` | n/a | yes |
 | domain | Domain for hosting gitlab functionality (ie mydomain.com would access gitlab at gitlab.mydomain.com) | `string` | `""` | no |
 | gitlab\_address\_name | Name of the address to use for GitLab ingress | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -198,43 +198,51 @@ resource "google_redis_instance" "gitlab" {
 
 // Cloud Storage
 resource "google_storage_bucket" "gitlab-backups" {
-  name     = "${var.project_id}-gitlab-backups"
-  location = var.region
+  name          = "${var.project_id}-gitlab-backups"
+  location      = var.region
+  force_destroy = var.allow_future_deletion
 }
 
 resource "google_storage_bucket" "gitlab-uploads" {
-  name     = "${var.project_id}-gitlab-uploads"
-  location = var.region
+  name          = "${var.project_id}-gitlab-uploads"
+  location      = var.region
+  force_destroy = var.allow_future_deletion
 }
 
 resource "google_storage_bucket" "gitlab-artifacts" {
-  name     = "${var.project_id}-gitlab-artifacts"
-  location = var.region
+  name          = "${var.project_id}-gitlab-artifacts"
+  location      = var.region
+  force_destroy = var.allow_future_deletion
 }
 
 resource "google_storage_bucket" "git-lfs" {
-  name     = "${var.project_id}-git-lfs"
-  location = var.region
+  name          = "${var.project_id}-git-lfs"
+  location      = var.region
+  force_destroy = var.allow_future_deletion
 }
 
 resource "google_storage_bucket" "gitlab-packages" {
-  name     = "${var.project_id}-gitlab-packages"
-  location = var.region
+  name          = "${var.project_id}-gitlab-packages"
+  location      = var.region
+  force_destroy = var.allow_future_deletion
 }
 
 resource "google_storage_bucket" "gitlab-registry" {
-  name     = "${var.project_id}-registry"
-  location = var.region
+  name          = "${var.project_id}-registry"
+  location      = var.region
+  force_destroy = var.allow_future_deletion
 }
 
 resource "google_storage_bucket" "gitlab-pseudo" {
-  name     = "${var.project_id}-pseudo"
-  location = var.region
+  name          = "${var.project_id}-pseudo"
+  location      = var.region
+  force_destroy = var.allow_future_deletion
 }
 
 resource "google_storage_bucket" "gitlab-runner-cache" {
-  name     = "${var.project_id}-runner-cache"
-  location = var.region
+  name          = "${var.project_id}-runner-cache"
+  location      = var.region
+  force_destroy = var.allow_future_deletion
 }
 // GKE Cluster
 module "gke" {

--- a/main.tf
+++ b/main.tf
@@ -200,49 +200,49 @@ resource "google_redis_instance" "gitlab" {
 resource "google_storage_bucket" "gitlab-backups" {
   name          = "${var.project_id}-gitlab-backups"
   location      = var.region
-  force_destroy = var.allow_future_deletion
+  force_destroy = var.allow_force_destroy
 }
 
 resource "google_storage_bucket" "gitlab-uploads" {
   name          = "${var.project_id}-gitlab-uploads"
   location      = var.region
-  force_destroy = var.allow_future_deletion
+  force_destroy = var.allow_force_destroy
 }
 
 resource "google_storage_bucket" "gitlab-artifacts" {
   name          = "${var.project_id}-gitlab-artifacts"
   location      = var.region
-  force_destroy = var.allow_future_deletion
+  force_destroy = var.allow_force_destroy
 }
 
 resource "google_storage_bucket" "git-lfs" {
   name          = "${var.project_id}-git-lfs"
   location      = var.region
-  force_destroy = var.allow_future_deletion
+  force_destroy = var.allow_force_destroy
 }
 
 resource "google_storage_bucket" "gitlab-packages" {
   name          = "${var.project_id}-gitlab-packages"
   location      = var.region
-  force_destroy = var.allow_future_deletion
+  force_destroy = var.allow_force_destroy
 }
 
 resource "google_storage_bucket" "gitlab-registry" {
   name          = "${var.project_id}-registry"
   location      = var.region
-  force_destroy = var.allow_future_deletion
+  force_destroy = var.allow_force_destroy
 }
 
 resource "google_storage_bucket" "gitlab-pseudo" {
   name          = "${var.project_id}-pseudo"
   location      = var.region
-  force_destroy = var.allow_future_deletion
+  force_destroy = var.allow_force_destroy
 }
 
 resource "google_storage_bucket" "gitlab-runner-cache" {
   name          = "${var.project_id}-runner-cache"
   location      = var.region
-  force_destroy = var.allow_future_deletion
+  force_destroy = var.allow_force_destroy
 }
 // GKE Cluster
 module "gke" {

--- a/variables.tf
+++ b/variables.tf
@@ -88,7 +88,7 @@ variable "helm_chart_version" {
   description = "Helm chart version to install during deployment"
 }
 
-variable "allow_future_deletion" {
+variable "allow_force_destroy" {
   type        = bool
   default     = false
   description = "Allows full cleanup of resources by disabling any deletion safe guards"

--- a/variables.tf
+++ b/variables.tf
@@ -81,8 +81,15 @@ variable "gitlab_services_subnet_cidr" {
   default     = "10.2.0.0/16"
   description = "Cidr range to use for gitlab GKE services subnet"
 }
+
 variable "helm_chart_version" {
   type        = string
   default     = "4.2.4"
   description = "Helm chart version to install during deployment"
+}
+
+variable "allow_future_deletion" {
+  type        = bool
+  default     = false
+  description = "Allows full cleanup of resources by disabling any deletion safe guards"
 }


### PR DESCRIPTION
Addresses #49 

I named the variable a bit generic because when we upgrade the google provider, deleting the google_sql_database_instance will require an additional [flag](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#deletion_protection), and I figured we could reuse this variable.