### PR TITLE
Feature/terraform 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ crash.log
 # version control.
 #
 # example.tfvars
-test/fixtures/shared/terraform.tfvars
+**/terraform.tfvars
+.terraform.lock.hcl
 
 credentials.json

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.13
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.0
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | allow\_force\_destroy | Allows full cleanup of resources by disabling any deletion safe guards | `bool` | `false` | no |
-| certmanager\_email | Email used to retrieve SSL certificates from Let's Encrypt | `any` | n/a | yes |
-| domain | Domain for hosting gitlab functionality (ie mydomain.com would access gitlab at gitlab.mydomain.com) | `string` | `""` | no |
+| certmanager\_email | Email used to retrieve SSL certificates from [Let's Encrypt](https://letsencrypt.org) | `any` | n/a | yes |
+| domain | Domain for hosting gitlab functionality (ie mydomain.com would access gitlab at `gitlab.mydomain.com` and the registry at `registry.mydomain.com`) | `string` | `""` | no |
 | gitlab\_address\_name | Name of the address to use for GitLab ingress | `string` | `""` | no |
 | gitlab\_db\_name | Instance name for the GitLab Postgres database. | `string` | `"gitlab-db"` | no |
 | gitlab\_db\_password | Password for the GitLab Postgres user | `string` | `""` | no |
@@ -44,9 +44,12 @@ Then perform the following commands on the root folder:
 | gitlab\_pods\_subnet\_cidr | Cidr range to use for gitlab GKE pods subnet | `string` | `"10.3.0.0/16"` | no |
 | gitlab\_runner\_install | Choose whether to install the gitlab runner in the cluster | `bool` | `true` | no |
 | gitlab\_services\_subnet\_cidr | Cidr range to use for gitlab GKE services subnet | `string` | `"10.2.0.0/16"` | no |
-| gke\_machine\_type | Machine type used for the node-pool | `string` | `"n1-standard-4"` | no |
-| gke\_version | Version of GKE to use for the GitLab cluster | `string` | `"1.16"` | no |
-| helm\_chart\_version | Helm chart version to install during deployment | `string` | `"4.2.4"` | no |
+| gke\_machine\_type | [Machine type](https://cloud.google.com/compute/docs/machine-types) used for the node-pool | `string` | `"n1-standard-4"` | no |
+| gke\_max\_node\_count | Maximum GKE nodes per availability zone | `number` | `2` | no |
+| gke\_min\_node\_count | Mininum GKE nodes per availability zone | `number` | `1` | no |
+| gke\_preemptible\_nodes | [Preemptible VMs](https://cloud.google.com/compute/docs/instances/preemptible) are instances that you can create and run at a much lower price than normal instances. However, Compute Engine might stop (preempt) these instances if it requires access to those resources for other tasks. They're suitable for a GKE development deployment. | `bool` | `false` | no |
+| gke\_release\_channel | Kubernetes releases updates often, to deliver security updates, fix known issues, and introduce new features. [Release channels](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) offer customers the ability to balance between stability and the feature set of the version deployed in the cluster. | `string` | `"REGULAR"` | no |
+| helm\_chart\_version | Helm chart version to install during deployment ([GitLab version mapping](https://docs.gitlab.com/charts/installation/version_mappings.html)) | `string` | `"5.0.3"` | no |
 | project\_id | GCP Project to deploy resources | `any` | n/a | yes |
 | region | GCP region to deploy resources to | `string` | `"us-central1"` | no |
 
@@ -76,8 +79,11 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 
 ### Software Dependencies
 ### Terraform
-- [Terraform](https://www.terraform.io/downloads.html) 0.13.x
-- [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) plugin v1.8.0
+- [Terraform](https://www.terraform.io/downloads.html) 1.0.x
+- [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) plugin v3.72.0
+- [terraform-provider-helm](https://github.com/hashicorp/terraform-provider-helm) plugin v2.2.0
+- [terraform-provider-kubernetes](https://github.com/hashicorp/terraform-provider-kubernetes) plugin v2.3.2
+- [terraform-provider-random](https://github.com/hashicorp/terraform-provider-random) plugin v3.1.0
 
 ### Configure a Service Account
 In order to execute this module you must have a Service Account with the
@@ -87,17 +93,17 @@ following project roles:
 ## Install
 
 ### Terraform
-Be sure you have the correct Terraform version (0.13.x), you can choose the binary here:
+Be sure you have the correct Terraform version 1.0.x), you can choose the binary here:
 - https://releases.hashicorp.com/terraform/
 
 ## File structure
 The project has the following folders and files:
 
-- /: root folder
-- /examples: examples for using this module
-- /helpers: Helper scripts
-- /test: Folders with files for testing the module (see Testing section on this file)
-- /main.tf: main file for this module, contains all the resources to create
-- /variables.tf: all the variables for the module
-- /output.tf: the outputs of the module
-- /README.md: this file
+- `/`: root folder
+- `/examples`: examples for using this module
+- `/helpers`: Helper scripts
+- `/test`: Folders with files for testing the module (see Testing section on this file)
+- `/main.tf`: main file for this module, contains all the resources to create
+- `/variables.tf`: all the variables for the module
+- `/output.tf`: the outputs of the module
+- `/README.md`: this file

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -38,6 +38,6 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.0'
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -22,4 +22,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.13'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '1.0'

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -14,16 +14,8 @@
  * limitations under the License.
  */
 
-provider "google" {
-  version = "~> 3.42.0"
-}
-
-provider "google-beta" {
-  version = "~> 3.42.0"
-}
-
 module "gke-gitlab" {
   source            = "../../"
-  project_id        = "${var.project_id}"
+  project_id        = var.project_id
   certmanager_email = "no-reply@${var.project_id}.example.com"
 }

--- a/examples/simple_example/outputs.tf
+++ b/examples/simple_example/outputs.tf
@@ -15,9 +15,9 @@
  */
 
 output "gitlab_url" {
-  value = "${module.gke-gitlab.gitlab_url}"
+  value = module.gke-gitlab.gitlab_url
 }
 
 output "root_password_instructions" {
-  value = "${module.gke-gitlab.root_password_instructions}"
+  value = module.gke-gitlab.root_password_instructions
 }

--- a/main.tf
+++ b/main.tf
@@ -16,10 +16,7 @@
 
 provider "google" {
   project = var.project_id
-}
-
-provider "google-beta" {
-  project = var.project_id
+  region  = var.region
 }
 
 locals {
@@ -32,50 +29,52 @@ resource "random_id" "suffix" {
   byte_length = 4
 }
 
-
-module "gke_auth" {
-  source  = "terraform-google-modules/kubernetes-engine/google//modules/auth"
-  version = "~> 10.0"
-
-  project_id   = module.project_services.project_id
-  cluster_name = module.gke.name
-  location     = module.gke.location
-
-  depends_on = [time_sleep.sleep_for_cluster_fix_helm_6361]
-}
+# Retrieve an access token
+data "google_client_config" "provider" {}
 
 provider "helm" {
   kubernetes {
-    load_config_file       = false
-    cluster_ca_certificate = module.gke_auth.cluster_ca_certificate
-    host                   = module.gke_auth.host
-    token                  = module.gke_auth.token
+    cluster_ca_certificate = base64decode(google_container_cluster.gitlab.master_auth[0].cluster_ca_certificate)
+    host                   = "https://${google_container_cluster.gitlab.endpoint}"
+    token                  = data.google_client_config.provider.access_token
   }
 }
 
 provider "kubernetes" {
-  load_config_file = false
-
-  cluster_ca_certificate = module.gke_auth.cluster_ca_certificate
-  host                   = module.gke_auth.host
-  token                  = module.gke_auth.token
+  cluster_ca_certificate = base64decode(google_container_cluster.gitlab.master_auth[0].cluster_ca_certificate)
+  host                   = "https://${google_container_cluster.gitlab.endpoint}"
+  token                  = data.google_client_config.provider.access_token
 }
 
 // Services
-module "project_services" {
-  source  = "terraform-google-modules/project-factory/google//modules/project_services"
-  version = "~> 9.0"
+resource "google_project_service" "container" {
+  project                    = var.project_id
+  service                    = "container.googleapis.com"
+  disable_dependent_services = true
+}
 
-  project_id                  = var.project_id
-  disable_services_on_destroy = false
+resource "google_project_service" "cloudresourcemanager" {
+  project                    = var.project_id
+  service                    = "cloudresourcemanager.googleapis.com"
+  disable_dependent_services = true
+}
 
-  activate_apis = [
-    "compute.googleapis.com",
-    "container.googleapis.com",
-    "servicenetworking.googleapis.com",
-    "cloudresourcemanager.googleapis.com",
-    "redis.googleapis.com"
-  ]
+resource "google_project_service" "compute" {
+  project                    = var.project_id
+  service                    = "compute.googleapis.com"
+  disable_dependent_services = true
+}
+
+resource "google_project_service" "servicenetworking" {
+  project                    = var.project_id
+  service                    = "servicenetworking.googleapis.com"
+  disable_dependent_services = true
+}
+
+resource "google_project_service" "redis" {
+  project                    = var.project_id
+  service                    = "redis.googleapis.com"
+  disable_dependent_services = true
 }
 
 // GCS Service Account
@@ -95,11 +94,20 @@ resource "google_project_iam_member" "project" {
   member  = "serviceAccount:${google_service_account.gitlab_gcs.email}"
 }
 
+// GKE Service Account
+resource "google_service_account" "gitlab_gke" {
+  account_id   = "gitlab-gke"
+  display_name = "Gitlab GKE Service Account"
+}
+
 // Networking
 resource "google_compute_network" "gitlab" {
   name                    = "gitlab"
-  project                 = module.project_services.project_id
+  project                 = var.project_id
   auto_create_subnetworks = false
+  depends_on = [
+    google_project_service.compute,
+  ]
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
@@ -124,28 +132,27 @@ resource "google_compute_address" "gitlab" {
   region       = var.region
   address_type = "EXTERNAL"
   description  = "Gitlab Ingress IP"
-  depends_on   = [module.project_services.project_id]
   count        = var.gitlab_address_name == "" ? 1 : 0
+  depends_on = [
+    google_project_service.compute
+  ]
 }
 
 // Database
 resource "google_compute_global_address" "gitlab_sql" {
-  provider      = google-beta
   project       = var.project_id
   name          = "gitlab-sql"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   network       = google_compute_network.gitlab.self_link
-  address       = "10.1.0.0"
   prefix_length = 16
 }
 
 resource "google_service_networking_connection" "private_vpc_connection" {
-  provider                = google-beta
   network                 = google_compute_network.gitlab.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.gitlab_sql.name]
-  depends_on              = [module.project_services.project_id]
+  depends_on              = [google_project_service.servicenetworking]
 }
 
 resource "google_sql_database_instance" "gitlab_db" {
@@ -153,6 +160,8 @@ resource "google_sql_database_instance" "gitlab_db" {
   name             = local.gitlab_db_name
   region           = var.region
   database_version = "POSTGRES_11"
+
+  deletion_protection = !var.allow_force_destroy
 
   settings {
     tier            = "db-custom-4-15360"
@@ -166,9 +175,8 @@ resource "google_sql_database_instance" "gitlab_db" {
 }
 
 resource "google_sql_database" "gitlabhq_production" {
-  name       = "gitlabhq_production"
-  instance   = google_sql_database_instance.gitlab_db.name
-  depends_on = [google_sql_user.gitlab]
+  name     = "gitlabhq_production"
+  instance = google_sql_database_instance.gitlab_db.name
 }
 
 resource "random_string" "autogenerated_gitlab_db_password" {
@@ -191,7 +199,7 @@ resource "google_redis_instance" "gitlab" {
   region             = var.region
   authorized_network = google_compute_network.gitlab.self_link
 
-  depends_on = [module.project_services.project_id]
+  depends_on = [google_project_service.redis]
 
   display_name = "GitLab Redis"
 }
@@ -244,40 +252,69 @@ resource "google_storage_bucket" "gitlab-runner-cache" {
   location      = var.region
   force_destroy = var.allow_force_destroy
 }
-// GKE Cluster
-module "gke" {
-  source  = "terraform-google-modules/kubernetes-engine/google"
-  version = "~> 12.0"
 
-  # Create an implicit dependency on service activation
-  project_id = module.project_services.project_id
-
-  name               = "gitlab"
-  region             = var.region
-  regional           = true
-  kubernetes_version = var.gke_version
+# GKE cluster
+resource "google_container_cluster" "gitlab" {
+  name     = "gitlab"
+  location = var.region
 
   remove_default_node_pool = true
   initial_node_count       = 1
 
-  network           = google_compute_network.gitlab.name
-  subnetwork        = google_compute_subnetwork.subnetwork.name
-  ip_range_pods     = "gitlab-cluster-pod-cidr"
-  ip_range_services = "gitlab-cluster-service-cidr"
+  network    = google_compute_network.gitlab.name
+  subnetwork = google_compute_subnetwork.subnetwork.name
 
-  issue_client_certificate = true
+  ip_allocation_policy {
+    cluster_secondary_range_name  = "gitlab-cluster-pod-cidr"
+    services_secondary_range_name = "gitlab-cluster-service-cidr"
+  }
 
-  node_pools = [
-    {
-      name         = "gitlab"
-      autoscaling  = false
-      machine_type = var.gke_machine_type
-      node_count   = 1
-    },
+  enable_shielded_nodes = true
+
+  release_channel {
+    channel = var.gke_release_channel
+  }
+
+  depends_on = [
+    google_project_service.compute,
+    google_project_service.container,
+    google_project_service.cloudresourcemanager
   ]
+}
 
-  node_pools_oauth_scopes = {
-    all = ["https://www.googleapis.com/auth/cloud-platform"]
+# Separately Managed Node Pool
+resource "google_container_node_pool" "gitlab_nodes" {
+  name       = "${google_container_cluster.gitlab.name}-node-pool"
+  location   = var.region
+  cluster    = google_container_cluster.gitlab.name
+  node_count = var.gke_min_node_count
+
+  node_config {
+    service_account = google_service_account.gitlab_gke.email
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    preemptible  = var.gke_preemptible_nodes
+    machine_type = var.gke_machine_type
+
+    shielded_instance_config {
+      enable_secure_boot          = true
+      enable_integrity_monitoring = true
+    }
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  autoscaling {
+    min_node_count = var.gke_min_node_count
+    max_node_count = var.gke_max_node_count
   }
 }
 
@@ -291,8 +328,6 @@ resource "kubernetes_storage_class" "pd-ssd" {
   parameters = {
     type = "pd-ssd"
   }
-
-  depends_on = [time_sleep.sleep_for_cluster_fix_helm_6361]
 }
 
 resource "kubernetes_secret" "gitlab_pg" {
@@ -303,8 +338,6 @@ resource "kubernetes_secret" "gitlab_pg" {
   data = {
     password = var.gitlab_db_password != "" ? var.gitlab_db_password : random_string.autogenerated_gitlab_db_password.result
   }
-
-  depends_on = [time_sleep.sleep_for_cluster_fix_helm_6361]
 }
 
 resource "kubernetes_secret" "gitlab_rails_storage" {
@@ -320,8 +353,6 @@ google_client_email: ${google_service_account.gitlab_gcs.email}
 google_json_key_string: '${base64decode(google_service_account_key.gitlab_gcs.private_key)}'
 EOT
   }
-
-  depends_on = [time_sleep.sleep_for_cluster_fix_helm_6361]
 }
 
 resource "kubernetes_secret" "gitlab_registry_storage" {
@@ -339,10 +370,7 @@ gcs:
   keyfile: /etc/docker/registry/storage/gcs.json
 EOT
   }
-
-  depends_on = [time_sleep.sleep_for_cluster_fix_helm_6361]
 }
-
 
 resource "kubernetes_secret" "gitlab_gcs_credentials" {
   metadata {
@@ -352,8 +380,6 @@ resource "kubernetes_secret" "gitlab_gcs_credentials" {
   data = {
     gcs-application-credentials-file = base64decode(google_service_account_key.gitlab_gcs.private_key)
   }
-
-  depends_on = [time_sleep.sleep_for_cluster_fix_helm_6361]
 }
 
 data "google_compute_address" "gitlab" {
@@ -366,11 +392,11 @@ data "google_compute_address" "gitlab" {
 
 locals {
   gitlab_address = var.gitlab_address_name == "" ? google_compute_address.gitlab.0.address : data.google_compute_address.gitlab.0.address
-  domain         = var.domain != "" ? var.domain : "${local.gitlab_address}.xip.io"
+  domain         = var.domain != "" ? var.domain : "${local.gitlab_address}.nip.io"
 }
 
 data "template_file" "helm_values" {
-  template = "${file("${path.module}/values.yaml.tpl")}"
+  template = file("${path.module}/values.yaml.tpl")
 
   vars = {
     DOMAIN                = local.domain
@@ -381,12 +407,6 @@ data "template_file" "helm_values" {
     CERT_MANAGER_EMAIL    = var.certmanager_email
     GITLAB_RUNNER_INSTALL = var.gitlab_runner_install
   }
-}
-
-resource "time_sleep" "sleep_for_cluster_fix_helm_6361" {
-  create_duration  = "180s"
-  destroy_duration = "180s"
-  depends_on       = [module.gke.endpoint, google_sql_database.gitlabhq_production]
 }
 
 resource "helm_release" "gitlab" {
@@ -406,6 +426,6 @@ resource "helm_release" "gitlab" {
     kubernetes_secret.gitlab_rails_storage,
     kubernetes_secret.gitlab_registry_storage,
     kubernetes_secret.gitlab_gcs_credentials,
-    time_sleep.sleep_for_cluster_fix_helm_6361,
+    google_container_node_pool.gitlab_nodes,
   ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,28 +25,29 @@ output "gitlab_url" {
 }
 
 output "cluster_name" {
-  value       = module.gke.name
+  value       = google_container_cluster.gitlab.name
   description = "Name of the GKE cluster that GitLab is deployed in."
 }
 
 output "cluster_location" {
-  value       = module.gke.location
+  value       = google_container_cluster.gitlab.location
   description = "Location of the GKE cluster that GitLab is deployed in."
 }
 
 output "cluster_ca_certificate" {
-  value       = module.gke_auth.cluster_ca_certificate
+  value       = google_container_cluster.gitlab.master_auth.0.cluster_ca_certificate
   description = "CA Certificate for the GKE cluster that GitLab is deployed in."
 }
 
 output "host" {
-  value       = module.gke_auth.host
+  value       = google_container_cluster.gitlab.endpoint
   description = "Host for the GKE cluster that GitLab is deployed in."
 }
 
 output "token" {
-  value       = module.gke_auth.token
+  value       = data.google_client_config.provider.access_token
   description = "Token for the GKE cluster that GitLab is deployed in."
+  sensitive   = true
 }
 
 output "root_password_instructions" {

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -16,14 +16,13 @@
 
 module "gke-gitlab-proj" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 9.0"
+  version = "~> 11.1"
 
-  name                 = "ci-gitlab"
-  random_project_id    = true
-  org_id               = var.org_id
-  folder_id            = var.folder_id
-  billing_account      = var.billing_account
-  skip_gcloud_download = true
+  name              = "ci-gitlab"
+  random_project_id = true
+  org_id            = var.org_id
+  folder_id         = var.folder_id
+  billing_account   = var.billing_account
 
   auto_create_network = true
 

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,15 +15,11 @@
  */
 
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.42"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 3.42"
+      version = "~> 3.72"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -19,22 +19,37 @@ variable "project_id" {
 }
 
 variable "domain" {
-  description = "Domain for hosting gitlab functionality (ie mydomain.com would access gitlab at gitlab.mydomain.com)"
+  description = "Domain for hosting gitlab functionality (ie mydomain.com would access gitlab at `gitlab.mydomain.com` and the registry at `registry.mydomain.com`)"
   default     = ""
 }
 
 variable "certmanager_email" {
-  description = "Email used to retrieve SSL certificates from Let's Encrypt"
+  description = "Email used to retrieve SSL certificates from [Let's Encrypt](https://letsencrypt.org)"
 }
 
-variable "gke_version" {
-  description = "Version of GKE to use for the GitLab cluster"
-  default     = "1.16"
+variable "gke_release_channel" {
+  description = "Kubernetes releases updates often, to deliver security updates, fix known issues, and introduce new features. [Release channels](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) offer customers the ability to balance between stability and the feature set of the version deployed in the cluster."
+  default     = "REGULAR"
 }
 
 variable "gke_machine_type" {
-  description = "Machine type used for the node-pool"
+  description = "[Machine type](https://cloud.google.com/compute/docs/machine-types) used for the node-pool"
   default     = "n1-standard-4"
+}
+
+variable "gke_preemptible_nodes" {
+  description = "[Preemptible VMs](https://cloud.google.com/compute/docs/instances/preemptible) are instances that you can create and run at a much lower price than normal instances. However, Compute Engine might stop (preempt) these instances if it requires access to those resources for other tasks. They're suitable for a GKE development deployment."
+  default     = false
+}
+
+variable "gke_min_node_count" {
+  description = "Mininum GKE nodes per availability zone"
+  default     = 1
+}
+
+variable "gke_max_node_count" {
+  description = "Maximum GKE nodes per availability zone"
+  default     = 2
 }
 
 variable "gitlab_db_name" {
@@ -84,8 +99,8 @@ variable "gitlab_services_subnet_cidr" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "4.2.4"
-  description = "Helm chart version to install during deployment"
+  default     = "5.0.3"
+  description = "Helm chart version to install during deployment ([GitLab version mapping](https://docs.gitlab.com/charts/installation/version_mappings.html))"
 }
 
 variable "allow_force_destroy" {

--- a/versions.tf
+++ b/versions.tf
@@ -15,43 +15,27 @@
  */
 
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = "~> 1.0"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.42"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 3.42"
+      version = "3.72"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 1.2.0"
+      version = "~> 2.2"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.11.0"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 2.1.2"
+      version = "~> 2.3"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.2.1"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.1.2"
+      version = "~> 3.1"
     }
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-gke-gitlab/v0.5.2"
-  }
-
-  provider_meta "google-beta" {
     module_name = "blueprints/terraform/terraform-google-gke-gitlab/v0.5.2"
   }
 }


### PR DESCRIPTION
This is a breaking change!

Features:
* use Terraform 1.0.0 and the latest releases for all the dependencies
* drop modules and use resources everywhere
* add cluster scaling
* use release channels to manage GKE versions
* use shielded nodes
* add preemptible nodes as a configuration option
* create a service account for GKE
* allow GCP to choose to choose the DB address
* Improve README.md
* update to latest GitLab release

Fixes:
* clean up versions.tf
* remove sleep_for_cluster_fix_helm_6361 and set dependencies correctly
* replace xip.io with nip.io

Known Issues:
* when running `terraform destroy` there's a race condition in DB destruction
* destroy will crash when deactivating compute services due to an SSD disk created by Helm