### PR TITLE
feat: switch provider from google-beta to google

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -130,7 +130,6 @@ resource "google_compute_address" "gitlab" {
 
 // Database
 resource "google_compute_global_address" "gitlab_sql" {
-  provider      = google-beta
   project       = var.project_id
   name          = "gitlab-sql"
   purpose       = "VPC_PEERING"
@@ -141,7 +140,6 @@ resource "google_compute_global_address" "gitlab_sql" {
 }
 
 resource "google_service_networking_connection" "private_vpc_connection" {
-  provider                = google-beta
   network                 = google_compute_network.gitlab.self_link
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.gitlab_sql.name]


### PR DESCRIPTION
With current minimum TPG, switching [google_compute_global_address](https://github.com/terraform-google-modules/terraform-google-gke-gitlab/blob/1971baaf005070bf971e2b401293ec15f11b466f/main.tf#L133) and [google_service_networking_connection](https://github.com/terraform-google-modules/terraform-google-gke-gitlab/blob/1971baaf005070bf971e2b401293ec15f11b466f/main.tf#L144) from google-beta to google.

Closes #95 