### PR TITLE
fix: Change helm config to use toolbox instead of deprecated task-runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Then perform the following commands on the root folder:
 | gitlab\_services\_subnet\_cidr | Cidr range to use for gitlab GKE services subnet | `string` | `"10.2.0.0/16"` | no |
 | gke\_machine\_type | Machine type used for the node-pool | `string` | `"n1-standard-4"` | no |
 | gke\_version | Version of GKE to use for the GitLab cluster | `string` | `"1.21"` | no |
-| helm\_chart\_version | Helm chart version to install during deployment | `string` | `"4.2.4"` | no |
+| helm\_chart\_version | Helm chart version to install during deployment | `string` | `"5.10.5"` | no |
 | project\_id | GCP Project to deploy resources | `string` | n/a | yes |
 | region | GCP region to deploy resources to | `string` | `"us-central1"` | no |
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Then perform the following commands on the root folder:
 | gitlab\_runner\_install | Choose whether to install the gitlab runner in the cluster | `bool` | `true` | no |
 | gitlab\_services\_subnet\_cidr | Cidr range to use for gitlab GKE services subnet | `string` | `"10.2.0.0/16"` | no |
 | gke\_machine\_type | Machine type used for the node-pool | `string` | `"n1-standard-4"` | no |
-| gke\_version | Version of GKE to use for the GitLab cluster | `string` | `"1.21"` | no |
+| gke\_version | Version of GKE to use for the GitLab cluster | `string` | `"1.23"` | no |
 | helm\_chart\_version | Helm chart version to install during deployment | `string` | `"5.10.5"` | no |
 | project\_id | GCP Project to deploy resources | `string` | n/a | yes |
 | region | GCP region to deploy resources to | `string` | `"us-central1"` | no |

--- a/values.yaml.tpl
+++ b/values.yaml.tpl
@@ -85,7 +85,7 @@ gitlab:
     persistence:
       size: 200Gi
       storageClass: "pd-ssd"
-  task-runner:
+  toolbox:
     backups:
       objectStorage:
         backend: gcs

--- a/variables.tf
+++ b/variables.tf
@@ -104,7 +104,7 @@ variable "gitlab_services_subnet_cidr" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "4.2.4"
+  default     = "5.10.5"
   description = "Helm chart version to install during deployment"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "certmanager_email" {
 variable "gke_version" {
   description = "Version of GKE to use for the GitLab cluster"
   type        = string
-  default     = "1.21"
+  default     = "1.23"
 }
 
 variable "gke_machine_type" {


### PR DESCRIPTION
- `task-runner` config was removed in helm chart 5+, causing newer versions to fail the gitlab dependency check.
- Older versions of the helm chart v4, no longer work because of k8s api changes
- GKE 1.21 is no longer available