### PR TITLE
fix: remove template provider

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -41,10 +41,6 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 2.2.1"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.1.2"
-    }
     time = {
       source  = "hashicorp/time"
       version = "~> 0.9"


### PR DESCRIPTION
The terraform template provider is deprecated, and causing issues with darwin_arm64 architecture. I am removing it and using the built-in function `templatefile`

`Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a package available for your current platform, darwin_arm64.`